### PR TITLE
Fix for --compass option

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -29,9 +29,9 @@ module.exports = class SassCompiler
       '--load-path', sysPath.dirname(path),
       '--no-cache',
     ]
-    options.push '--compass' if @compass
     options.push '--scss' if /\.scss$/.test path
     execute = =>
+      options.push '--compass' if @compass
       sass = spawn @_bin, options
       sass.stdout.on 'data', (buffer) ->
         result += buffer.toString()


### PR DESCRIPTION
The check for adding the --compass option was being performed before the compass command had finished executing. I moved it into the execute function. This may fix #7, as I am using bootstrap-sass and have a config.rb in my project root that requires it, and I'm now able to @import 'bootstrap' in my stylesheets.
