### PR TITLE
Added support for sass imports underscore naming convention.

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -64,7 +64,7 @@ module.exports = class SassCompiler
       .map (match) =>
         match[1]
       .filter (path) =>
-        !!path and path isnt 'compass'
+        !!path and !path.match(/^compass/)
       .map (path) =>
         if sysPath.extname(path) isnt ".#{@extension}"
           path + ".#{@extension}"
@@ -75,5 +75,14 @@ module.exports = class SassCompiler
           sysPath.join @config.paths.root, path[1..]
         else
           sysPath.join parent, path
+
+    # Sass convention is that @import "rounded"; will load "_rounded.scss"
+    # http://sass-lang.com/tutorial.html#id1
+    for path in dependencies
+      dir = sysPath.dirname(path)
+      file = sysPath.basename(path)
+      if file[0] isnt "_"
+        dependencies.push sysPath.join(dir, "_#{file}")
+
     process.nextTick =>
       callback null, dependencies


### PR DESCRIPTION
I had some issues getting Sass working with Brunch, and eventually I figured out that changing

```
@import "foo/bar";
```

to

```
@import "foo/_bar";
```

 fixed the issues.

But having `@import "myfile";` resolve to `_myfile.scss` is actually a Sass naming convention (http://sass-lang.com/tutorial.html#id1), so I patched sass-brunch to look for extra dependencies that might exist.
