### PR TITLE
Add coffee-script to development dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "1.8.1",
+    "coffee-script": "1.6.3",
     "chai": "1.4.2"
   }
 }


### PR DESCRIPTION
`$ npm test` won't run without this.

```
$ npm test

> sass-brunch@1.5.2 test /Users/fujimura/work/sass-brunch
> node_modules/.bin/mocha --compilers coffee:coffee-script --require test/common.js


module.js:340
    throw err;
          ^
Error: Cannot find module 'coffee-script'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at /Users/fujimura/work/sass-brunch/node_modules/mocha/bin/_mocha:251:3
    at Array.forEach (native)
    at Object.<anonymous> (/Users/fujimura/work/sass-brunch/node_modules/mocha/bin/_mocha:245:19)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:901:3
npm ERR! weird error 8
npm ERR! not ok code 0
```
