### PR TITLE
Fixes buffering to stdin stream for large scss files.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -105,7 +105,13 @@ module.exports = SassCompiler = (function() {
       } else {
         sass.on('close', onExit);
       }
-      return sass.stdin.end(data);
+      if (sass.stdin.write(data)) {
+        return sass.stdin.end();
+      } else {
+        return sass.stdin.on('drain', function() {
+          return sass.stdin.end();
+        });
+      }
     };
     delay = function() {
       if (_this.compass != null) {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -64,7 +64,10 @@ module.exports = class SassCompiler
         sass.on 'exit', onExit
       else
         sass.on 'close', onExit
-      sass.stdin.end data
+      if sass.stdin.write data
+        sass.stdin.end()
+      else
+        sass.stdin.on 'drain', -> sass.stdin.end()
 
     delay = =>
       if @compass?


### PR DESCRIPTION
With large scss files I get syntax errors because the stdin stream ends before sending all the data to the process. I've fixed this by using `.write()` instead of `.end()` and waiting for the `drain` event if the stream returns false indicating that it is buffered.

The file that needs this fix is over 40k long. It works in the terminal with just `sass styles.css.scss` but failed with `brunch build`. After this fix it works perfectly.
