### PR TITLE
Fixing bundle running

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ module.exports = SassCompiler = (function() {
   SassCompiler.prototype._compass_bin = 'compass';
 
   function SassCompiler(config) {
-    var env, k, v, _ref1, _ref2,
+    var bin_cmd, compass_bin_cmd, env, k, v, _ref1, _ref2, _ref3, _ref4,
       _this = this;
     this.config = config;
     this.gem_home = (_ref1 = this.config.plugins) != null ? (_ref2 = _ref1.sass) != null ? _ref2.gem_home : void 0 : void 0;
@@ -52,17 +52,20 @@ module.exports = SassCompiler = (function() {
       this._bin = this.config.plugins.sass.gem_home + '/bin/sass';
       this._compass_bin = this.config.plugins.sass.gem_home + '/bin/compass';
     }
-    if (this.config.plugins.sass.useBundler) {
-      this._bin = "bundle exec " + this._bin;
-      this._compass_bin = "bundle exec " + this._compass_bin;
+    if ((_ref3 = this.config.plugins) != null ? (_ref4 = _ref3.sass) != null ? _ref4.useBundler : void 0 : void 0) {
+      bin_cmd = "bundle exec " + this._bin;
+      compass_bin_cmd = "bundle exec " + this._compass_bin;
+    } else {
+      bin_cmd = this._bin;
+      compass_bin_cmd = this._compass_bin;
     }
-    exec("" + this._bin + " --version", this.mod_env, function(error, stdout, stderr) {
+    exec("" + bin_cmd + " --version", this.mod_env, function(error, stdout, stderr) {
       if (error) {
         console.error("You need to have Sass on your system");
         return console.error("Execute `gem install sass`");
       }
     });
-    exec("" + this._compass_bin + " --version", this.mod_env, function(error, stdout, stderr) {
+    exec("" + compass_bin_cmd + " --version", this.mod_env, function(error, stdout, stderr) {
       return _this.compass = !error;
     });
     this.getDependencies = progeny({
@@ -87,11 +90,17 @@ module.exports = SassCompiler = (function() {
       options.push('--scss');
     }
     execute = function() {
-      var onExit, sass;
+      var bin, onExit, sass, _ref5, _ref6;
       if (_this.compass) {
         options.push('--compass');
       }
-      sass = spawn(_this._bin, options, _this.mod_env);
+      if ((_ref5 = _this.config.plugins) != null ? (_ref6 = _ref5.sass) != null ? _ref6.useBundler : void 0 : void 0) {
+        bin = 'bundle';
+        options.unshift('exec', 'sass');
+      } else {
+        bin = _this._bin;
+      }
+      sass = spawn(bin, options, _this.mod_env);
       sass.stdout.on('data', function(buffer) {
         return result += buffer.toString();
       });

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -24,7 +24,7 @@ module.exports = class SassCompiler
       @_compass_bin = @config.plugins.sass.gem_home + '/bin/compass'
 
 
-    if @config.plugins.sass.useBundler
+    if @config.plugins?.sass?.useBundler
       bin_cmd = "bundle exec #{@_bin}"
       compass_bin_cmd = "bundle exec #{@_compass_bin}"
     else
@@ -61,7 +61,7 @@ module.exports = class SassCompiler
     execute = =>
       options.push '--compass' if @compass
 
-      if @config.plugins.sass.useBundler
+      if @config.plugins?.sass?.useBundler
         bin = 'bundle'
         options.unshift('exec', 'sass')
       else bin = @_bin


### PR DESCRIPTION
I didn't realize spawn expected just one non-space-separated string. This should fix weird event.js errors cropping up.

Ideally, it'd be nice to code this in a super sexy way, [like grunt's sass compiler task](https://github.com/gruntjs/grunt-contrib-sass/blob/master/tasks/sass.js) which has a super caliente [way of handling arguments](https://github.com/gruntjs/grunt-contrib-sass/blob/master/tasks/sass.js#L76-L89).
