### PR TITLE
Fix for #33: Closed socket.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -93,6 +93,10 @@ module.exports = SassCompiler = (function() {
     }
     execute = function() {
       var onExit, sass;
+      if (process.platform === 'win32') {
+        cmd = ['cmd', '/c', '"' + cmd[0] + '"'].concat(cmd.slice(1));
+        _this.mod_env.windowsVerbatimArguments = true;
+      }
       sass = spawn(cmd[0], cmd.slice(1), _this.mod_env);
       sass.stdout.on('data', function(buffer) {
         return result += buffer.toString();

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -60,6 +60,11 @@ module.exports = class SassCompiler
     cmd.push.apply(cmd, @conf.options) if @conf?.options?
 
     execute = =>
+      # windows is kind of a jerk sometimes.
+      if process.platform is 'win32'
+        cmd = ['cmd', '/c', '"' + cmd[0] + '"'].concat cmd.slice 1
+        @mod_env.windowsVerbatimArguments = true
+
       sass = spawn cmd[0], cmd.slice(1), @mod_env
       sass.stdout.on 'data', (buffer) ->
         result += buffer.toString()


### PR DESCRIPTION
#33 seems to be related to isaacs/npm-www#74, whose root cause is in turn covered by joyent/node#2318.

The problem is that child_process.spawn ignores the PATHEXT completion for batch files. Thus, just invoking `sass` or `compass` is not enough, since it should be `sass.bat` or `compass.bat`. The proposed workaround is to call `cmd.exe` as an intermediary shell that takes care of that resolution. I took the fix from isaacs/npm-www#74. 

Licenses should be compatible (MIT and BSD).
