### PR TITLE
Add includePaths option in config and pass it to libsass

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ config =
       mode: 'ruby'
 ```
 
+Set additional include paths for libsass:
+```coffeescript
+config =
+  plugins:
+    sass:
+      options:
+        includePaths: ['bower_components/foundation/scss']
+```
+
 Print line number references as comments or sass's FireSass fake media query:
 
 ```coffeescript

--- a/index.js
+++ b/index.js
@@ -76,6 +76,11 @@ SassCompiler.prototype._checkRuby = function() {
 };
 
 SassCompiler.prototype._nativeCompile = function(data, path, callback) {
+  var includePaths = [this.rootPath, sysPath.dirname(path)];
+  if (this.config.options != null && this.config.options.includePaths != null) {
+    includePaths.push.apply(includePaths, this.config.options.includePaths);
+  }
+
   libsass.render({
     data: data,
     success: (function(css) {
@@ -84,7 +89,7 @@ SassCompiler.prototype._nativeCompile = function(data, path, callback) {
     error: (function(error) {
       callback(error);
     }),
-    includePaths: [this.rootPath, sysPath.dirname(path)],
+    includePaths: includePaths,
     outputStyle: 'nested',
     sourceComments: !this.optimize
   });
@@ -109,7 +114,7 @@ SassCompiler.prototype._rubyCompile = function(data, path, callback) {
       hasComments = this.config.debug === 'comments';
       cmd.push(hasComments ? '--line-comments' : '--debug-info');
     }
-    
+
     if (!sassRe.test(path)) cmd.push('--scss');
     if (this.compass) cmd.push('--compass');
     if (this.config.options != null) cmd.push.apply(cmd, this.config.options);


### PR DESCRIPTION
Added `includePaths` option which is passed to libsass, required to work with sass includes that are outside the project including those that are in bower packages like the foundation framework. Updated the README with an example of how to use this.
