### PR TITLE
Update node-sass version to 0.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "progeny": "~0.1.1",
-    "node-sass": "~0.7.0",
+    "node-sass": "~0.8.3",
     "promise": "~3.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Adds bootstrap-sass support.

Simple change - don't want to maintain my own fork for it :)
