### PR TITLE
Use the includePaths options with the ruby compiler as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ config =
       mode: 'ruby'
 ```
 
-Set additional include paths for libsass:
+Set additional include paths:
 ```coffeescript
 config =
   plugins:


### PR DESCRIPTION
I ran into issue trying to import both compass and foundation.  It looks like it defaults to the ruby compiler if compass is imported, but the ruby compiler ignores the `includePaths` config option.  This fixed it for me.
