### PR TITLE
Pegging version dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "test": "node_modules/.bin/mocha"
   },
   "dependencies": {
-    "progeny": "~0.2.1",
-    "node-sass": "~0.9.3",
-    "promise": "~3.2.0"
+    "progeny": "0.2.1",
+    "node-sass": "0.9.3",
+    "promise": "3.2.0"
   },
   "devDependencies": {
     "mocha": "1.11.0",


### PR DESCRIPTION
A lot of times, using a "~version" can be bad news for stability, as we're seeing today with sass-brunch.
Pegging versions exactly by removing the "~" significantly improves reliability.
