### PR TITLE
Support node-sass 2.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,8 +92,9 @@ SassCompiler.prototype._getIncludePaths = function(path) {
 SassCompiler.prototype._nativeCompile = function(source, callback) {
   libsass.render({
     data: source.data,
-    success: (function(css) {
-      callback(null, css);
+    success: (function(data) {
+      if(data.css) data = data.css;
+      callback(null, data);
     }),
     error: (function(error) {
       callback(error);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "node-sass": "^1.0.1",
+    "node-sass": ">=1.0.1 <3.0.0",
     "progeny": "~0.5.1",
     "promise": "^6.0.0"
   },


### PR DESCRIPTION
A minimal change is required to make the new libsass work. I have decided to support both old and new versions but we may choose to migrate to 2.0.0 completely.