### PR TITLE
Support empty compilation results on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ SassCompiler.prototype._nativeCompile = function(source, callback) {
     data: source.data,
     success: (function(data) {
       if(data.css) {
-        callback(null, data);
+        callback(null, data.css);
       } else {
         callback(null, null);
       }

--- a/index.js
+++ b/index.js
@@ -93,8 +93,11 @@ SassCompiler.prototype._nativeCompile = function(source, callback) {
   libsass.render({
     data: source.data,
     success: (function(data) {
-      if(data.css) data = data.css;
-      callback(null, data);
+      if(data.css) {
+        callback(null, data);
+      } else {
+        callback(null, null);
+      }
     }),
     error: (function(error) {
       callback(error);


### PR DESCRIPTION
When I tried  to compile variables.scss on bootstrap, it crashes on window. I had this bug since the node-sass 2.0.0 release. I fixed it up real quick. Now it works :)