### PR TITLE
Bump to node-sass 3.0 with sass support

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,18 +92,20 @@ SassCompiler.prototype._getIncludePaths = function(path) {
 
 SassCompiler.prototype._nativeCompile = function(source, callback) {
   libsass.render({
-    data: source.data,
-    success: (function(data) {
-      if('css' in data) data = data.css;
-      callback(null, data);
-    }),
-    error: (function(error) {
-      callback(error.message || util.inspect(error));
-    }),
-    includePaths: this._getIncludePaths(source.path),
-    outputStyle: 'nested',
-    sourceComments: !this.optimize
-  });
+      file: source.path,
+      data: source.data,
+      includePaths: this._getIncludePaths(source.path),
+      outputStyle: (this.optimize ? "nested" : 'compressed'),
+      sourceComments: !this.optimize,
+      indentedSyntax: sassRe.test(source.path)
+    },
+    function(error, result) {
+      if (error) {
+        callback(error.message || util.inspect(error));
+      } else {
+        callback(null, result.css.toString());
+      }
+    });
 };
 
 SassCompiler.prototype._rubyCompile = function(source, callback) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "node-sass": ">=1.0.1 <3.0.0",
+    "node-sass": "^3.0.0",
     "progeny": "~0.5.1",
     "promise": "^6.0.0"
   },

--- a/test.js
+++ b/test.js
@@ -24,7 +24,7 @@ describe('sass-brunch plugin', function() {
     expect(plugin).to.be.ok;
   });
 
-  it('should has #compile method', function() {
+  it('should have a #compile method', function() {
     expect(plugin.compile).to.be.an.instanceof(Function);
   });
 


### PR DESCRIPTION
Similar to #84, this patch bumps up `node-sass` to version 3, but this PR retains support for `sass`. I'm happy to either merge this into #84 or work to have this pulled.