### PR TITLE
Add the precision option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ config =
       debug: 'comments' # or set to 'debug' for the FireSass-style output
 ```
 
+Set the precision for arithmetic operations. This is useful for building Bootstrap, Zurb Foundation, and the like.
+
+```coffeescript
+config =
+  plugins:
+    sass:
+      precision: 8
+```
+
 Allow the ruby compiler to write its normal cache files in `.sass-cache` (disabled by default).
 This can vastly improve compilation time.
 

--- a/index.js
+++ b/index.js
@@ -94,6 +94,7 @@ SassCompiler.prototype._nativeCompile = function(source, callback) {
   libsass.render({
     file: source.path,
     data: source.data,
+    precision: this.config.precision,
     includePaths: this._getIncludePaths(source.path),
     outputStyle: (this.optimize ? "compressed" : "nested"),
     sourceComments: !this.optimize,
@@ -133,6 +134,7 @@ SassCompiler.prototype._rubyCompile = function(source, callback) {
       cmd.push(hasComments ? '--line-comments' : '--debug-info');
     }
 
+    if (this.config.precision) cmd.push('--precision=' + this.config.precision);
     if (!sassRe.test(source.path)) cmd.push('--scss');
     if (source.compass && this.compass) cmd.push('--compass');
     if (this.config.options != null) cmd.push.apply(cmd, this.config.options);

--- a/test.js
+++ b/test.js
@@ -3,114 +3,195 @@ var Plugin = require('./');
 var sysPath = require('path');
 var fs = require('fs');
 
-describe('sass-brunch plugin', function() {
-  var plugin;
-  var fileName = 'app/styles/style.scss';
-
-  beforeEach(function() {
-    var config = Object.freeze({
-      paths: {root: '.'},
-      optimize: true
-      // ,plugins: {
-      //   sass: {
-      //     mode: 'ruby'
-      //   }
-      // }
-    });
-    plugin = new Plugin(config);
+describe('sass-brunch plugin using', function () {
+  runTests.call(this, {
+    mode: 'native',
+    compress: function (s) { return s.replace(/[\s;]*/g, '') + '\n'; }
   });
 
-  it('should be an object', function() {
-    expect(plugin).to.be.ok;
-  });
-
-  it('should have a #compile method', function() {
-    expect(plugin.compile).to.be.an.instanceof(Function);
-  });
-
-  it('should compile and produce valid result for scss', function(done) {
-    var content = '$a: 5px; .test {\n  border-radius: $a; }\n';
-    var expected = '.test {\n  border-radius: 5px; }\n';
-
-    plugin.compile(content, 'file.scss', function(error, data) {
-      expect(error).not.to.be.ok;
-      expect(data).to.equal(expected);
-      done();
-    });
-  });
-
-  it('should compile and produce valid result for sass', function(done) {
-    var content = '$a: 5px\n.test\n  border-radius: $a';
-    var expected = '.test {\n  border-radius: 5px; }\n';
-
-    plugin.compile(content, 'file.sass', function(error, data) {
-      expect(error).not.to.be.ok;
-      expect(data).to.equal(expected);
-      done();
-    });
-  });
-
-  it('should output valid deps', function(done) {
-    var content = "\
-    @import \'valid1\';\n\
-    @import \'../../vendor/styles/valid3\';\n\
-    ";
-
-    fs.mkdirSync('app');
-    fs.mkdirSync('vendor');
-    fs.mkdirSync(sysPath.join('app', 'styles'));
-    fs.mkdirSync(sysPath.join('vendor', 'styles'));
-    fs.writeFileSync(sysPath.join('app', 'styles', '_valid1.sass'), '@import \"./valid2.scss\";\n');
-    fs.writeFileSync(sysPath.join('app', 'styles', 'valid2.scss'), '\n');
-    fs.writeFileSync(sysPath.join('vendor', 'styles', '_valid3.scss'), '\n');
-
-    var expected = [
-      sysPath.join('app', 'styles', '_valid1.sass'),
-      sysPath.join('app', 'styles', 'valid2.scss'),
-      sysPath.join('vendor', 'styles', '_valid3.scss')
-    ];
-
-    plugin.getDependencies(content, fileName, function(error, dependencies) {
-      fs.unlinkSync(sysPath.join('app', 'styles', '_valid1.sass'));
-      fs.unlinkSync(sysPath.join('app', 'styles', 'valid2.scss'));
-      fs.unlinkSync(sysPath.join('vendor', 'styles', '_valid3.scss'));
-      fs.rmdirSync(sysPath.join('app', 'styles'));
-      fs.rmdirSync(sysPath.join('vendor', 'styles'));
-      fs.rmdirSync('app');
-      fs.rmdirSync('vendor');
-      expect(error).not.to.be.ok;
-      expect(dependencies.length).to.eql(expected.length);
-      expected.forEach(function (item){
-        expect(dependencies.indexOf(item)).to.be.greaterThan(-1);
-      });
-      done();
-    });
-  });
-
-  it('should return empty result for empty source', function(done) {
-    var content = '   \t\n';
-    var expected = '';
-    plugin.compile(content, 'file.scss', function(error, data) {
-      expect(error).not.to.be.ok;
-      expect(data).to.equal(expected)
-      done();
-    });
-  });
-
-  it('should save without error', function(done) {
-    var content = '$var: () !default;' +
-      '@function test($value) {\n' +
-      '\t@if index($var, $value) {\n' +
-      '\t\t@return false;' +
-      '\t}' +
-      '\t$var: append($var, $value) !global;\n' +
-      '\t@return true;' +
-      '}';
-      var expected = '';
-      plugin.compile(content, 'no-content.scss', function(error, data) {
-          expect(error).not.to.be.ok;
-          expect(data).to.equal(expected);
-          done();
-      });
-  });
+  if (process.env.TRAVIS !== 'true') {
+    runTests.call(this, {mode: 'ruby'});
+  }
 });
+
+function runTests(o) {
+  var mode = o.mode;
+  var compress = o.compress || function (s) { return s; };
+
+  describe(mode, function() {
+    var plugin;
+    var config;
+    var fileName = 'app/styles/style.scss';
+
+    beforeEach(function() {
+      config = Object.freeze({
+        paths: {root: '.'},
+        optimize: true
+        ,plugins: {
+          sass: {
+            mode: mode
+          }
+        }
+      });
+      plugin = new Plugin(config);
+    });
+
+    it('should be an object', function() {
+      expect(plugin).to.be.ok;
+    });
+
+    it('should have a #compile method', function() {
+      expect(plugin.compile).to.be.an.instanceof(Function);
+    });
+
+    it('should compile and produce valid result for scss', function(done) {
+      var content = '$a: 5px; .test {\n  border-radius: $a; }\n';
+      var expected = '.test {\n  border-radius: 5px; }\n';
+
+      plugin.compile(content, 'file.scss', function(error, data) {
+        expect(error).not.to.be.ok;
+        expect(data).to.equal(compress(expected));
+        done();
+      });
+    });
+
+    it('should default to five decimals of precision for scss', function(done) {
+      var content = '$a: 5px; .test {\n  border-radius: $a/3; }\n';
+      var expected = '1.66667px';
+
+      plugin.compile(content, 'file.scss', function(error, data) {
+        expect(error).not.to.be.ok;
+        expect(data).to.contain(expected);
+        done();
+      });
+    });
+
+    it('should calculate to the indicated level of precision for scss', function(done) {
+      var content = '$a: 5px; .test {\n  border-radius: $a/3; }\n';
+      var expected = '1.66666667px';
+      plugin = new Plugin({
+        paths: config.paths,
+        optimize: config.optimize,
+        plugins: {
+          sass: {
+            precision: 8,
+            mode: mode
+          }
+        }
+      });
+
+      plugin.compile(content, 'file.scss', function(error, data) {
+        expect(error).not.to.be.ok;
+        expect(data).to.contain(expected);
+        done();
+      });
+    });
+
+    it('should compile and produce valid result for sass', function(done) {
+      var content = '$a: 5px\n.test\n  border-radius: $a';
+      var expected = '.test {\n  border-radius: 5px; }\n';
+
+      plugin.compile(content, 'file.sass', function(error, data) {
+        expect(error).not.to.be.ok;
+        expect(data).to.equal(compress(expected));
+        done();
+      });
+    });
+
+    it('should default to five decimals of precision for sass', function(done) {
+      var content = '$a: 5px\n.test\n  border-radius: $a/3';
+      var expected = '1.66667px';
+
+      plugin.compile(content, 'file.sass', function(error, data) {
+        expect(error).not.to.be.ok;
+        expect(data).to.contain(expected);
+        done();
+      });
+    });
+
+    it('should calculate to the indicated level of precision for sass', function(done) {
+      var content = '$a: 5px\n.test\n  border-radius: $a/3';
+      var expected = '1.66666667px';
+      plugin = new Plugin({
+        paths: config.paths,
+        optimize: config.optimize,
+        plugins: {
+          sass: {
+            precision: 8,
+            mode: mode
+          }
+        }
+      });
+
+      plugin.compile(content, 'file.sass', function(error, data) {
+        expect(error).not.to.be.ok;
+        expect(data).to.contain(expected);
+        done();
+      });
+    });
+
+    it('should output valid deps', function(done) {
+      var content = "\
+      @import \'valid1\';\n\
+      @import \'../../vendor/styles/valid3\';\n\
+      ";
+
+      fs.mkdirSync('app');
+      fs.mkdirSync('vendor');
+      fs.mkdirSync(sysPath.join('app', 'styles'));
+      fs.mkdirSync(sysPath.join('vendor', 'styles'));
+      fs.writeFileSync(sysPath.join('app', 'styles', '_valid1.sass'), '@import \"./valid2.scss\";\n');
+      fs.writeFileSync(sysPath.join('app', 'styles', 'valid2.scss'), '\n');
+      fs.writeFileSync(sysPath.join('vendor', 'styles', '_valid3.scss'), '\n');
+
+      var expected = [
+        sysPath.join('app', 'styles', '_valid1.sass'),
+        sysPath.join('app', 'styles', 'valid2.scss'),
+        sysPath.join('vendor', 'styles', '_valid3.scss')
+      ];
+
+      plugin.getDependencies(content, fileName, function(error, dependencies) {
+        fs.unlinkSync(sysPath.join('app', 'styles', '_valid1.sass'));
+        fs.unlinkSync(sysPath.join('app', 'styles', 'valid2.scss'));
+        fs.unlinkSync(sysPath.join('vendor', 'styles', '_valid3.scss'));
+        fs.rmdirSync(sysPath.join('app', 'styles'));
+        fs.rmdirSync(sysPath.join('vendor', 'styles'));
+        fs.rmdirSync('app');
+        fs.rmdirSync('vendor');
+        expect(error).not.to.be.ok;
+        expect(dependencies.length).to.eql(expected.length);
+        expected.forEach(function (item){
+          expect(dependencies.indexOf(item)).to.be.greaterThan(-1);
+        });
+        done();
+      });
+    });
+
+    it('should return empty result for empty source', function(done) {
+      var content = '   \t\n';
+      var expected = '';
+      plugin.compile(content, 'file.scss', function(error, data) {
+        expect(error).not.to.be.ok;
+        expect(data).to.equal(expected)
+        done();
+      });
+    });
+
+    it('should save without error', function(done) {
+      var content = '$var: () !default;' +
+        '@function test($value) {\n' +
+        '\t@if index($var, $value) {\n' +
+        '\t\t@return false;' +
+        '\t}' +
+        '\t$var: append($var, $value) !global;\n' +
+        '\t@return true;' +
+        '}';
+        var expected = '';
+        plugin.compile(content, 'no-content.scss', function(error, data) {
+            expect(error).not.to.be.ok;
+            expect(data).to.equal(expected);
+            done();
+        });
+    });
+  });
+};


### PR DESCRIPTION
> Made the precision option available to the configuration block.
> Added two tests for default precision of 5 and a specified precision.
> Updated the README.

All: I wanted to make sure I tested both `ruby-sass` and `libsass`; hence the refactoring of the tests. It's probably a little controversial, so I'll defer to your style demands.

I also added a guard on the `ruby-sass` tests because they run long and, on Travis, I'm sure they'll run for incredibly long.