### PR TITLE
Implement embedded source maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ config =
       allowCache: true
 ```
 
+To enable embedded source maps, pass the option `sourceMapEmbed`. This is only supported in _native_ mode; Ruby Sass isn't supported.
+
+```coffeescript
+config =
+  plugins:
+    sass:
+      sourceMapEmbed: true
+```
+
 To include the source files' name/path in either debug mode, create a parent file that `@include` your actual sass/scss source. Make sure the source files are renamed to start with an underscore (`_file.scss`), or otherwise exclude them from the build so they don't get double-included.
 
 To pass any other options to sass:

--- a/index.js
+++ b/index.js
@@ -148,7 +148,8 @@ class SassCompiler {
         indentedSyntax: sassRe.test(source.path),
         outFile: 'a.css',
         functions: this.config.functions,
-        sourceMap: true
+        sourceMap: true,
+        sourceMapEmbed: !this.optimize && this.config.sourceMapEmbed
       },
       (error, result) => {
         if (error) {


### PR DESCRIPTION
Pass `sourceMapEmbed: true` as an option.