### PR TITLE
Fix ‘debug’ option for native compiler.

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,13 +139,16 @@ class SassCompiler {
 
   _nativeCompile(source) {
     return new Promise((resolve, reject) => {
+      var debugMode = this.config.debug;
+      var hasComments = debugMode === 'comments' && !this.optimize
+
       libsass.render({
         file: source.path,
         data: source.data,
         precision: this.config.precision,
         includePaths: this._getIncludePaths(source.path),
         outputStyle: (this.optimize ? 'compressed' : 'nested'),
-        sourceComments: !this.optimize,
+        sourceComments: hasComments,
         indentedSyntax: sassRe.test(source.path),
         outFile: 'a.css',
         functions: this.config.functions,

--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ class SassCompiler {
   _nativeCompile(source) {
     return new Promise((resolve, reject) => {
       var debugMode = this.config.debug;
-      var hasComments = debugMode === 'comments' && !this.optimize
+      var hasComments = debugMode === 'comments' && !this.optimize;
 
       libsass.render({
         file: source.path,


### PR DESCRIPTION
Allows to define when native compiler is in use.

```javascript
config = {
  plugins: {
    sass: {
      debug: 'comments'
    }
  }
}
```
