### PR TITLE
Added an ignore option for CSSModules

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,23 @@ var style = require('./title.scss');
 <h1 className={style.title}>Yo</h1>
 ```
 
-Note: enabling `cssModules` does so for every stylesheet in your project, so it's all-or-nothing. Even the files you don't require will be transformed into CSS modules (aka will have obfuscated class names, like turn `.title` into `._title_fdphn_1`).
+Note: enabling `cssModules` does so for every stylesheet in your project, even the files you don't require will be transformed into CSS modules (aka will have obfuscated class names, like turn `.title` into `._title_fdphn_1`).
+
+You must use the ignore option to specifically opt out of files or directories where you don't want to use cssModules.
+
+The ignore option takes an array of matches. [Anymatch](https://github.com/es128/anymatch) is used to handle the matching. See the [anymatch documentation](https://github.com/es128/anymatch) for more information.
+```javascript
+module.exports = {
+  // ...
+  plugins: {
+    css: {
+      modules: {
+        ignore: [/file\.css/, /some\/path\/to\/ignore/]
+      }
+    }
+  }
+};
+```
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -72,9 +72,9 @@ class SassCompiler {
     this.config = (cfg.plugins && cfg.plugins.sass) || {};
     this.modules = this.config.modules || this.config.cssModules;
 
-    if (this.modules && this.config.modules.ignore) {
-      this.isIgnored = anymatch(this.config.modules.ignore);
-      delete this.config.modules.ignore;
+    if (this.modules && this.modules.ignore) {
+      this.isIgnored = anymatch(this.modules.ignore);
+      delete this.modules.ignore;
     } else {
       this.isIgnored = anymatch([]);
     }
@@ -235,7 +235,7 @@ class SassCompiler {
         return this._nativeCompile(source);
       }
     }).then(params => {
-      if (this.modules && !this.isIgnored(params.path)) {
+      if (this.modules && !this.isIgnored(path)) {
         const moduleOptions = this.modules === true ? {} : this.modules;
         return cssModulify(path, params.data, params.map, moduleOptions);
       } else {

--- a/package.json
+++ b/package.json
@@ -22,11 +22,12 @@
     "test": "node_modules/.bin/eslint index.js && node_modules/.bin/mocha"
   },
   "dependencies": {
+    "anymatch": "^1.3.0",
     "node-sass": "~3.8.0",
-    "progeny": "~0.5.1",
-    "promise": "~6.0.0",
     "postcss": "~5.1.2",
-    "postcss-modules": "~0.5.0"
+    "postcss-modules": "~0.5.0",
+    "progeny": "~0.5.1",
+    "promise": "~6.0.0"
   },
   "devDependencies": {
     "mocha": "^2.0.1",

--- a/test.js
+++ b/test.js
@@ -185,8 +185,53 @@ function runTests(o) {
           done();
         }, error => expect(error).not.to.be.ok);
     });
+
+    it('should compile with modules', function(done) {
+      var content = '.class {color: #6b0;}';
+      var expected = /^\._class_/
+
+      newPlugin = new Plugin({
+        paths: {root: '.'},
+        plugins: {
+          sass: {
+            mode: mode,
+            modules: true,
+          }
+        }
+      });
+
+      newPlugin.compile({data: content, path: 'file.scss'}).then(result => {
+        var data = result.data;
+        expect(data).to.match(expected);
+        done();
+      }, error => expect(error).not.to.be.ok)
+      .catch( (err) => done(err) );
+    });
+
+    it('should skip modulifying files passed to ignore', function(done) {
+      var content = '.class {color: #6b0;}';
+      var expected = /^\.class \{/
+
+      newPlugin = new Plugin({
+        paths: {root: '.'},
+        plugins: {
+          sass: {
+            mode: mode,
+            modules: {ignore: [/file\.scss/]}
+          }
+        }
+      });
+
+      newPlugin.compile({data: content, path: 'file.scss'}).then(result => {
+        var data = result.data;
+        expect(data).to.match(expected);
+        done();
+      }, error => expect(error).not.to.be.ok)
+      .catch( (err) => done(err) );
+    });
   });
 };
+
 
 describe('sass-brunch plugin using native', function() {
   var compress = function (s) { return s.replace(/[\s;]*/g, '') + '\n\n'; };


### PR DESCRIPTION
I added the following to the documentation, it sums things up pretty well.

Note: enabling `cssModules` does so for every stylesheet in your project, even the files you don't require will be transformed into CSS modules (aka will have obfuscated class names, like turn `.title` into `._title_fdphn_1`).

You must use the ignore option to specifically opt out of files or directories where you don't want to use cssModules.

The ignore option takes an array of matches. [Anymatch](https://github.com/es128/anymatch) is used to handle the matching. See the [anymatch documentation](https://github.com/es128/anymatch) for more information.
```javascript
module.exports = {
  // ...
  plugins: {
    css: {
      modules: {
        ignore: [/file\.css/, /some\/path\/to\/ignore/]
      }
    }
  }
};
```
