### PR TITLE
Fix error messages from the native compiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,7 +166,7 @@ class SassCompiler {
       },
       (error, result) => {
         if (error) {
-          reject(error.message || util.inspect(error));
+          reject(error);
         } else {
           const css = result.css.toString().replace('/*# sourceMappingURL=a.css.map */', '');
           const map = JSON.parse(result.map.toString());


### PR DESCRIPTION
Before:

    $ brunch b
    28 Oct 12:02:21 - error: Compiling of app/test.scss failed.
    28 Oct 12:02:21 - info: compiled in 493 ms

After:

    $ brunch b
    28 Oct 12:03:02 - error: Compiling of app/test.scss failed. Invalid CSS after "a": expected "{", was ""
    28 Oct 12:03:02 - info: compiled in 464 ms