### PR TITLE
Remove built in support of css modules in favor of postcss-brunch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# sass-brunch 2.9.0 (Nov 16, 2016)
+* Remove built in module support and delegate modules to `postcss-brunch`
+
+===
+
 # sass-brunch 2.6.2 (Apr 5, 2016)
 * Add source map support for `native`
 

--- a/README.md
+++ b/README.md
@@ -110,68 +110,31 @@ config =
 ```
 
 ### CSS Modules
-Starting Brunch `2.6.0`, you can use CSS Modules with css-brunch. To enable it, change your config to:
 
-```javascript
-module.exports = {
-  // ...
+Support for CSS modules has been dropped in v2.9.
+
+If you need built in support, downgrade to v2.6, but we recommend to user
+`postcss-brunch` directly.
+
+Example brunch configuration with CSS modules and autoprefixer:
+
+```json
   plugins: {
     sass: {
+      options: {
+      }
+    },
+    postcss: {
+      processors: [
+        require('autoprefixer')(['last 8 versions'])
+      ],
       modules: true
-    }
+    },
   }
-};
 ```
 
-You can also pass options directly to
-[postcss-modules](https://github.com/css-modules/postcss-modules):
-
-```javascript
-module.exports = {
-  // ...
-  plugins: {
-    sass: {
-      modules: {
-        generateScopedName: '[name]__[local]___[hash:base64:5]'
-      }
-    }
-  }
-};
-```
-
-Then, author your styles like you normally would:
-
-```scss
-.title {
-  font-size: 32px;
-}
-```
-
-And reference CSS class names by requiring the specific style into your javascript:
-
-```javascript
-var style = require('./title.scss');
-
-<h1 className={style.title}>Yo</h1>
-```
-
-Note: enabling `cssModules` does so for every stylesheet in your project, even the files you don't require will be transformed into CSS modules (aka will have obfuscated class names, like turn `.title` into `._title_fdphn_1`).
-
-You must use the ignore option to specifically opt out of files or directories where you don't want to use cssModules.
-
-The ignore option takes an array of matches. [Anymatch](https://github.com/es128/anymatch) is used to handle the matching. See the [anymatch documentation](https://github.com/es128/anymatch) for more information.
-```javascript
-module.exports = {
-  // ...
-  plugins: {
-    css: {
-      modules: {
-        ignore: [/file\.css/, /some\/path\/to\/ignore/]
-      }
-    }
-  }
-};
-```
+Refer to `postcss-brunch` [documentation](https://github.com/brunch/postcss-brunch#css-modules)
+for more configuration options.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-brunch",
-  "version": "2.7.0",
+  "version": "2.9.0",
   "description": "Adds Sass support to brunch.",
   "author": "Paul Miller (http://paulmillr.com/)",
   "homepage": "https://github.com/brunch/sass-brunch",
@@ -22,10 +22,7 @@
     "test": "node_modules/.bin/eslint index.js && node_modules/.bin/mocha"
   },
   "dependencies": {
-    "anymatch": "^1.3.0",
     "node-sass": "~3.8.0",
-    "postcss": "~5.1.2",
-    "postcss-modules": "~0.5.0",
     "progeny": "~0.5.1",
     "promise": "~6.0.0"
   },

--- a/test.js
+++ b/test.js
@@ -186,49 +186,6 @@ function runTests(o) {
         }, error => expect(error).not.to.be.ok);
     });
 
-    it('should compile with modules', function(done) {
-      var content = '.class {color: #6b0;}';
-      var expected = /^\._class_/
-
-      newPlugin = new Plugin({
-        paths: {root: '.'},
-        plugins: {
-          sass: {
-            mode: mode,
-            modules: true,
-          }
-        }
-      });
-
-      newPlugin.compile({data: content, path: 'file.scss'}).then(result => {
-        var data = result.data;
-        expect(data).to.match(expected);
-        done();
-      }, error => expect(error).not.to.be.ok)
-      .catch( (err) => done(err) );
-    });
-
-    it('should skip modulifying files passed to ignore', function(done) {
-      var content = '.class {color: #6b0;}';
-      var expected = /^\.class \{/
-
-      newPlugin = new Plugin({
-        paths: {root: '.'},
-        plugins: {
-          sass: {
-            mode: mode,
-            modules: {ignore: [/file\.scss/]}
-          }
-        }
-      });
-
-      newPlugin.compile({data: content, path: 'file.scss'}).then(result => {
-        var data = result.data;
-        expect(data).to.match(expected);
-        done();
-      }, error => expect(error).not.to.be.ok)
-      .catch( (err) => done(err) );
-    });
   });
 };
 


### PR DESCRIPTION
With https://github.com/brunch/postcss-brunch/pull/33

should fix https://github.com/brunch/sass-brunch/issues/124

Even if not absolutely required for it to work, I think it is good to drop this code.

I made some tests with `postcss-brunch` and `sass-brunch` and everything works (modules and autoprefixer).

I think a test suite that test `sass-brunch` with `postcss-brunch` and a few processors should live somewhere. I don't know in what repo to put it as neither are absolutely dependent on the other.

I bumped the version because this might break backward compatibility.