### PR TITLE
Convert README CoffeeScript to JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,91 +22,120 @@ set `native` mode.
 
 Note that source maps are only supported in the `native` mode.
 
-```coffeescript
-config =
-  plugins:
-    sass:
-      mode: 'ruby' # set to 'native' to force libsass
+```javascript
+config = {
+  plugins: {
+    sass: {
+      mode: 'ruby' // set to 'native' to force libsass
+    }
+  }
+}
 ```
 
 Set additional include paths:
-```coffeescript
-config =
-  plugins:
-    sass:
-      options:
+```javascript
+config = {
+  plugins: {
+    sass: {
+      options: {
         includePaths: ['node_modules/foundation/scss']
+      }
+    }
+  }
+}
 ```
 
 Print line number references as comments or sass's FireSass fake media query:
 
-```coffeescript
-config =
-  plugins:
-    sass:
-      debug: 'comments' # or set to 'debug' for the FireSass-style output
+```javascript
+config = {
+  plugins: {
+    sass: {
+      debug: 'comments' // or set to 'debug' for the FireSass-style output
+    }
+  }
+}
 ```
 
 Set the precision for arithmetic operations. This is useful for building Bootstrap, Zurb Foundation, and the like.
 
-```coffeescript
-config =
-  plugins:
-    sass:
+```javascript
+config = {
+  plugins: {
+    sass: {
       precision: 8
+    }
+  }
+}
 ```
 
 Allow the ruby compiler to write its normal cache files in `.sass-cache` (disabled by default).
 This can vastly improve compilation time.
 
-```coffeescript
-config =
-  plugins:
-    sass:
+```javascript
+config = {
+  plugins: {
+    sass: {
       allowCache: true
+    }
+  }
+}
 ```
 
 To enable embedded source maps, pass the option `sourceMapEmbed`. This is only supported in _native_ mode; Ruby Sass isn't supported.
 
-```coffeescript
-config =
-  plugins:
-    sass:
+```javascript
+config = {
+  plugins: {
+    sass: {
       sourceMapEmbed: true
+    }
+  }
+}
 ```
 
 To include the source files' name/path in either debug mode, create a parent file that `@include` your actual sass/scss source. Make sure the source files are renamed to start with an underscore (`_file.scss`), or otherwise exclude them from the build so they don't get double-included.
 
 To pass any other options to sass:
 
-```coffeescript
-config =
-  plugins:
-    sass:
+```javascript
+config = {
+  plugins: {
+    sass: {
       options: ['--quiet']
+    }
+  }
+}
 ```
 
 Use sass/compass installed in custom location:
-```coffeescript
-config =
-  plugins:
-    sass:
+```javascript
+config = {
+  plugins: {
+    sass: {
       gem_home: './gems'
+    }
+  }
+}
 ```
 This could be useful for the environment which doesn't allow to install gems globally, such as CI server.
 
 Use libsass [experimental custom functions](https://github.com/sass/node-sass#functions--v300---experimental):
 
-```coffeescript
-types = require('node-sass').types
-config =
-  plugins:
-    sass:
-      mode: 'native' # custom functions are only supported in 'native' mode
-      functions:
-        sin: (val) -> types.Number(Math.sin(val.getValue()))
-        cos: (val) -> types.Number(Math.cos(val.getValue()))
-        tan: (val) -> types.Number(Math.tan(val.getValue()))
+```javascript
+var types = require('node-sass').types
+config = {
+  plugins: {
+    sass: {
+      mode: 'native', // custom functions are only supported in 'native' mode
+      functions: {
+        sin: function(val) { types.Number(Math.sin(val.getValue())) },
+        cos: function(val) { types.Number(Math.cos(val.getValue())) },
+        tan: function(val) { types.Number(Math.tan(val.getValue())) }
+      }
+    }
+  }
+}
 ```
 
 ### CSS Modules

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ set `native` mode.
 Note that source maps are only supported in the `native` mode.
 
 ```javascript
-config = {
+module.exports = {
   plugins: {
     sass: {
       mode: 'ruby' // set to 'native' to force libsass
@@ -34,7 +34,7 @@ config = {
 
 Set additional include paths:
 ```javascript
-config = {
+module.exports = {
   plugins: {
     sass: {
       options: {
@@ -48,7 +48,7 @@ config = {
 Print line number references as comments or sass's FireSass fake media query:
 
 ```javascript
-config = {
+module.exports = {
   plugins: {
     sass: {
       debug: 'comments' // or set to 'debug' for the FireSass-style output
@@ -60,7 +60,7 @@ config = {
 Set the precision for arithmetic operations. This is useful for building Bootstrap, Zurb Foundation, and the like.
 
 ```javascript
-config = {
+module.exports = {
   plugins: {
     sass: {
       precision: 8
@@ -73,7 +73,7 @@ Allow the ruby compiler to write its normal cache files in `.sass-cache` (disabl
 This can vastly improve compilation time.
 
 ```javascript
-config = {
+module.exports = {
   plugins: {
     sass: {
       allowCache: true
@@ -85,7 +85,7 @@ config = {
 To enable embedded source maps, pass the option `sourceMapEmbed`. This is only supported in _native_ mode; Ruby Sass isn't supported.
 
 ```javascript
-config = {
+module.exports = {
   plugins: {
     sass: {
       sourceMapEmbed: true
@@ -99,7 +99,7 @@ To include the source files' name/path in either debug mode, create a parent fil
 To pass any other options to sass:
 
 ```javascript
-config = {
+module.exports = {
   plugins: {
     sass: {
       options: ['--quiet']
@@ -110,7 +110,7 @@ config = {
 
 Use sass/compass installed in custom location:
 ```javascript
-config = {
+module.exports = {
   plugins: {
     sass: {
       gem_home: './gems'
@@ -124,7 +124,7 @@ Use libsass [experimental custom functions](https://github.com/sass/node-sass#fu
 
 ```javascript
 var types = require('node-sass').types
-config = {
+module.exports = {
   plugins: {
     sass: {
       mode: 'native', // custom functions are only supported in 'native' mode


### PR DESCRIPTION
CoffeeScript can be difficult for beginners to translate to JavaScript
or even understand the difference between the two. This is especially true
with frameworks like Phoenix, which uses brunch as for their front-end
assets throwing beginners directly into JavaScript.

It's also reasonable to assume that users of CoffeeScript will have a
much easier time converting from JavaScript to CoffeeScript.