### PR TITLE
Upgrade node-sass to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "anymatch": "^1.3.0",
-    "node-sass": "~3.8.0",
+    "node-sass": "^4.0.0",
     "postcss": "~5.1.2",
     "postcss-modules": "~0.5.0",
     "progeny": "~0.5.1",


### PR DESCRIPTION
[`package.json`](https://github.com/brunch/sass-brunch/blob/2.9.0/package.json) is currently requiring [node-sass v3.8.0](https://github.com/brunch/sass-brunch/blob/2.9.0/package.json#L26).

It'd be good to upgrade to [v4](https://github.com/sass/node-sass/tags). I've been encountering [this bug](https://github.com/sass/node-sass/issues/1592) frequently, and it's been fixed in v4 :tada:

The reason for the increment of the major semver from 3 to 4 seems to be [this PR](https://github.com/sass/node-sass/pull/1800), which upgrades [LibSass](https://github.com/sass/libsass) to [v3.4.0](https://github.com/sass/libsass/releases/tag/3.4.0) (a significant update).

I'm using this PR's [upgrade-nodesass](https://github.com/michaelhogg/sass-brunch/tree/upgrade-nodesass) branch in my current Brunch project, and I haven't encountered any issues with the upgrade to node-sass v4.