### PR TITLE
Add targetExtension; add support for postcss-brunch

### DIFF
--- a/index.js
+++ b/index.js
@@ -250,6 +250,7 @@ class SassCompiler {
 SassCompiler.prototype.brunchPlugin = true;
 SassCompiler.prototype.type = 'stylesheet';
 SassCompiler.prototype.pattern = /\.s[ac]ss$/;
+SassCompiler.prototype.targetExtension = 'css';
 SassCompiler.prototype._bin = isWindows ? 'sass.bat' : 'sass';
 SassCompiler.prototype._compass_bin = isWindows ? 'compass.bat' : 'compass'; //eslint-disable-line camelcase
 


### PR DESCRIPTION
Fixes #124.
Fixes brunch/postcss-brunch#31.
Closes brunch/postcss-brunch#33.
Fixes brunch/brunch#1619.

HOWEVER:

I had to make the following change to postcss-brunch when testing:

```diff
diff --git a/index.js b/index.js
index 6c49ab4..bfe011b 100644
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ class PostCSSCompiler {
 			file.data = '';
 		}
 		if (file.map) {
-			opts.map.prev = file.map.toJSON();
+			opts.map.prev = file.map.toJSON ? file.map.toJSON() : file.map;
 		}
 
 		return this.processor.process(file.data, opts).then(result => {
```

`file.map` was somehow a raw JavaScript object, not a SourceMapGenerator as are always (as far as I know) passed to plugins. I guess this needs to be fixed in brunch – it shouldn't pass anything other than SourceMapGenerators to plugins, should it?