### PR TITLE
Remove sass globbing and add targetExtension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<div style="display:block;padding:15px;background-color:tomato;border:2px dashed #8b0000;border-radius:6px;text-align:center">
+    <b style="display:block;font-size:32px;">Forked from brunch/sass-brunch</b>The original Plugin didn't worked properly and made me pissed, this is better.
+</div>
+
 ## sass-brunch
 Adds Sass support to
 [brunch](http://brunch.io).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-<div style="display:block;padding:15px;background-color:tomato;border:2px dashed #8b0000;border-radius:6px;text-align:center">
-    <b style="display:block;font-size:32px;">Forked from brunch/sass-brunch</b>The original Plugin didn't worked properly and made me pissed, this is better.
-</div>
+# Forked from brunch/sass-brunch
+The original Plugin didn't worked properly and made me pissed, this is better.
+
+---
 
 ## sass-brunch
 Adds Sass support to

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@
 const cp = require('child_process'), spawn = cp.spawn, exec = cp.exec;
 const sysPath = require('path');
 const progeny = require('progeny');
+const deasync = require('deasync');
 const libsass = require('node-sass');
 const os = require('os');
 const anymatch = require('anymatch');
@@ -75,7 +76,7 @@ const promiseSpawnAndPipe = (cmd, args, env, data) => {
 };
 
 class SassCompiler {
-  constructor(cfg) {
+  constructor (cfg) {
     if (cfg == null) cfg = {};
     this.rootPath = cfg.paths.root;
     this.optimize = cfg.optimize;
@@ -110,9 +111,11 @@ class SassCompiler {
 
     this.bundler = this.config.useBundler;
     this.prefix = this.bundler ? 'bundle exec ' : '';
+
+    this._nativeCompileSync = deasync(this._nativeCompile);
   }
 
-  _checkRuby() {
+  _checkRuby () {
     const prefix = this.prefix;
     const env = this.env;
     const sassCmd = `${prefix}${this._bin} --version`;
@@ -138,7 +141,7 @@ class SassCompiler {
     this.rubyPromise = Promise.all([sassPromise, compassPromise]);
   }
 
-  _getIncludePaths(path) {
+  _getIncludePaths (path) {
     let includePaths = [this.rootPath, sysPath.dirname(path)];
     if (Array.isArray(this.includePaths)) {
       includePaths = includePaths.concat(this.includePaths);
@@ -146,37 +149,38 @@ class SassCompiler {
     return includePaths;
   }
 
-  _nativeCompile(source) {
+  _nativeCompile (source) {
     return new Promise((resolve, reject) => {
       var debugMode = this.config.debug;
       var hasComments = debugMode === 'comments' && !this.optimize;
 
       libsass.render({
-        file: source.path,
-        data: source.data,
-        precision: this.config.precision,
-        includePaths: this._getIncludePaths(source.path),
-        outputStyle: this.optimize ? 'compressed' : 'nested',
-        sourceComments: hasComments,
-        indentedSyntax: sassRe.test(source.path),
-        outFile: 'a.css',
-        functions: this.config.functions,
-        importer: this.config.importer,
-        sourceMap: true,
-        sourceMapEmbed: !this.optimize && this.config.sourceMapEmbed,
-      },
-      (error, result) => {
-        if (error) {
-          return reject(formatError(source.path, error));
-        }
-        const data = result.css.toString().replace('/*# sourceMappingURL=a.css.map */', '');
-        const map = JSON.parse(result.map.toString());
-        resolve({data, map});
-      });
+          file: source.path,
+          data: source.data,
+          precision: this.config.precision,
+          includePaths: this._getIncludePaths(source.path),
+          outputStyle: this.optimize ? 'compressed' : 'nested',
+          sourceComments: hasComments,
+          indentedSyntax: sassRe.test(source.path),
+          outFile: 'a.css',
+          functions: this.config.functions,
+          importer: this.config.importer,
+          sourceMap: true,
+          sourceMapEmbed: !this.optimize && this.config.sourceMapEmbed,
+        },
+        (error, result) => {
+          if (error) {
+            return reject(formatError(source.path, error));
+          }
+          const data = result.css.toString().replace('/*# sourceMappingURL=a.css.map */', '');
+          const includedPaths = result.stat.includePaths;
+          const map = JSON.parse(result.map.toString());
+          resolve({data, map, includedPaths});
+        });
     });
   }
 
-  _rubyCompile(source) {
+  _rubyCompile (source) {
     if (this.rubyPromise == null) this._checkRuby();
     let cmd = [this._bin, '--stdin'];
 
@@ -210,16 +214,11 @@ class SassCompiler {
     });
   }
 
-  get getDependencies() {
-    return progeny({
-      rootPath: this.rootPath,
-      altPaths: this.includePaths,
-      reverseArgs: true,
-      globDeps: true,
-    });
+  getDependencies (file) {
+    return this._nativeCompileSync(file).includedPaths;
   }
 
-  get seekCompass() {
+  get seekCompass () {
     return promisify(progeny({
       rootPath: this.rootPath,
       exclusion: '',
@@ -227,15 +226,15 @@ class SassCompiler {
     }));
   }
 
-  compile(params) {
+  compile (params) {
     const data = params.data;
     const path = params.path;
 
     // skip empty source files
     if (!data.trim().length) return Promise.resolve({data: ''});
-    
+
     // skip submodules
-    if(sysPath.basename(path).startsWith('_')) return Promise.resolve({data: ''})
+    if (sysPath.basename(path).startsWith('_')) return Promise.resolve({data: ''})
 
     return this.seekCompass(path, data).then(imports => {
       const source = {

--- a/index.js
+++ b/index.js
@@ -233,6 +233,9 @@ class SassCompiler {
 
     // skip empty source files
     if (!data.trim().length) return Promise.resolve({data: ''});
+    
+    // skip submodules
+    if(sysPath.basename(path).startsWith('_')) return Promise.resolve({data: ''})
 
     return this.seekCompass(path, data).then(imports => {
       const source = {

--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ const libsass = require('node-sass');
 const os = require('os');
 const anymatch = require('anymatch');
 const promisify = require('micro-promisify');
-const nodeSassGlobbing = require('node-sass-globbing');
 
 const postcss = require('postcss');
 const postcssModules = require('postcss-modules');
@@ -162,9 +161,9 @@ class SassCompiler {
         indentedSyntax: sassRe.test(source.path),
         outFile: 'a.css',
         functions: this.config.functions,
+        importer: this.config.importer,
         sourceMap: true,
         sourceMapEmbed: !this.optimize && this.config.sourceMapEmbed,
-        importer: nodeSassGlobbing,
       },
       (error, result) => {
         if (error) {

--- a/index.js
+++ b/index.js
@@ -262,6 +262,7 @@ class SassCompiler {
 SassCompiler.prototype.brunchPlugin = true;
 SassCompiler.prototype.type = 'stylesheet';
 SassCompiler.prototype.pattern = /\.s[ac]ss$/;
+SassCompiler.prototype.targetExtension = 'css';
 SassCompiler.prototype._bin = isWindows ? 'sass.bat' : 'sass';
 SassCompiler.prototype._compass_bin = isWindows ? 'compass.bat' : 'compass';
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "anymatch": "^1.3.0",
     "micro-promisify": "~0.1.1",
     "node-sass": "^4.0.0",
-    "node-sass-globbing": "0.0.23",
     "postcss": "~5.1.2",
     "postcss-modules": "~0.5.0",
     "progeny": "~0.11.0"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "anymatch": "^1.3.0",
+    "deasync": "^0.1.9",
     "micro-promisify": "~0.1.1",
     "node-sass": "^4.0.0",
     "postcss": "~5.1.2",
@@ -36,6 +37,6 @@
     "mocha": "^2.0.1"
   },
   "eslintConfig": {
-    "extends": "brunch" 
+    "extends": "brunch"
   }
 }


### PR DESCRIPTION
Related with #149, if a sass-globber is needed, the user should define that for their project inside their respective config.

Another problem was that you couldn't _properly_ use `sass-brunch` in combination with `postcss-brunch`, by adding the `targetExtension`  property, the resulting css will be routed through the proper plugins.