### PR TITLE
Upgrade node-sass to 4.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "anymatch": "^1.3.0",
     "micro-promisify": "~0.1.1",
-    "node-sass": "^4.5.3",
+    "node-sass": "~4.5.3",
     "node-sass-globbing": "0.0.23",
     "postcss": "~5.1.2",
     "postcss-modules": "~0.5.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "anymatch": "^1.3.0",
     "micro-promisify": "~0.1.1",
-    "node-sass": "^4.0.0",
+    "node-sass": "^4.5.3",
     "node-sass-globbing": "0.0.23",
     "postcss": "~5.1.2",
     "postcss-modules": "~0.5.0",


### PR DESCRIPTION
This is an attempt to address #146 using Node 7.2.1 on Ubuntu. All tests in test.js passed successfully. I tested the sample repo in #141 (https://github.com/paulmillr/sass-test) and sass-brunch worked w/o issues. In addition, running `brunch build --production` (with a few SASS styles and 1 partial) did not produce any issues. Using an ampersand (&) rule also worked correctly.

@paulmillr mentioned that the latest version of node-sass at the time (4.5.0) broke sass-brunch, but it is not clear what it broke exactly.