### PR TITLE
Release v2.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# sass-brunch 2.10.5 (Oct 31, 2016)
+* Updated dependencies
+
 # sass-brunch 2.6.2 (Apr 5, 2016)
 * Add source map support for `native`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-brunch",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-brunch",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "description": "Adds Sass support to Brunch.",
   "author": "Paul Miller (http://paulmillr.com/)",
   "homepage": "https://github.com/brunch/sass-brunch",


### PR DESCRIPTION
GitHub repo has updated dependencies but there were not any npm release. As v2.10.4 is already released so it looks like release should have v2.10.5