### PR TITLE
Bump dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   "dependencies": {
     "anymatch": "~1.3.2",
     "micro-promisify": "~0.1.1",
-    "node-sass": "~4.5.3",
+    "node-sass": "~4.7.2",
     "node-sass-globbing": "0.0.23",
-    "postcss": "~6.0.8",
-    "postcss-modules": "~0.8.0",
+    "postcss": "~6.0.14",
+    "postcss-modules": "~1.1.0",
     "progeny": "~0.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Update `node-sass`, `postcss` and `postcss-modules` to their latest versions.