### PR TITLE
Increment package as well as node-sass version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-brunch",
-  "version": "2.10.8",
+  "version": "2.10.9",
   "description": "Adds Sass support to Brunch.",
   "author": "Paul Miller (https://paulmillr.com/)",
   "homepage": "https://github.com/brunch/sass-brunch",
@@ -24,7 +24,7 @@
   "dependencies": {
     "anymatch": "~1.3.2",
     "micro-promisify": "~0.1.1",
-    "node-sass": "~4.12.0",
+    "node-sass": "^4.13.0",
     "node-sass-globbing": "0.0.23",
     "postcss": "~6.0.8",
     "postcss-modules": "~1.1.0",


### PR DESCRIPTION
Hi Paul, please merge this pull request to make sass-brunch work with Node 13. Since node-sass v4.13.0 is backwards-compatible with all Node versions down to v.0.10, nothing will break: https://github.com/sass/node-sass/releases/tag/v4.13.0