### PR TITLE
Fixes 194

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ class SassCompiler {
       map.sources = map.sources.map(src => sysPath.relative(
         this.rootPath,
         // Brunch expects this to be a path, and doesn't handle URLs.
-        src.replace('file://', '')
+        src.replace('file:///', '')
       ));
 
       const params = {data, map};


### PR DESCRIPTION
`map.sources` after compilation contains strings like "file:///C:/myproject/app/styles.scss". To generate correct relative paths to the file from the project folder, the "file:///" (three forward slashes) must be removed.

No test case, because the error only occurs in Brunch after it processes the data returned from the compile method.