### PR TITLE
#194 Fix source path names for windows, fixed test

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ class SassCompiler {
       map.sources = map.sources.map(src => sysPath.relative(
         this.rootPath,
         // Brunch expects this to be a path, and doesn't handle URLs.
-        src.replace('file:///', '')
+        sysPath.sep === '\\' ? src.replace('file:///', '') : src.replace('file://', '')
       ));
 
       const params = {data, map};

--- a/test.js
+++ b/test.js
@@ -90,6 +90,10 @@ function runTests(settings) {
         );
     });
 
+    function convertBackslashes(path){
+      return sysPath.sep === '\\' ? path.replace(/\\/g, '/') : file;
+    }
+
     it('should output valid deps', done => {
       const content = `
       @import 'valid1';
@@ -114,7 +118,7 @@ function runTests(settings) {
         sysPath.join('vendor', 'styles', '_valid3.scss'),
         sysPath.join('app', 'styles', 'globbed', '_globbed1.sass'),
         sysPath.join('app', 'styles', 'globbed', '_globbed2.sass'),
-      ];
+      ].map(convertBackslashes);
 
       plugin.getDependencies(content, fileName, (error, dependencies) => {
         fs.unlinkSync(sysPath.join('app', 'styles', 'globbed', '_globbed1.sass'));
@@ -129,12 +133,12 @@ function runTests(settings) {
         fs.rmdirSync('vendor');
 
         expect(error).not.to.be.ok;
-        expect(dependencies.length).to.eql(expected.length);
+        const dependenciesConverted = dependencies.map(convertBackslashes);
 
-        console.log(dependencies);
+        expect(dependenciesConverted.length).to.eql(expected.length);
 
         expected.forEach(item =>
-          expect(dependencies.indexOf(item)).to.be.greaterThan(-1)
+          expect(dependenciesConverted.indexOf(item)).to.be.greaterThan(-1)
         );
 
         done();


### PR DESCRIPTION
The existing fix broke the linux builds:
```
21:11:04 - info: compiling
21:11:05 - error: Source map generation failed for 'builds/proj/app/style/_fonts.scss':  ENOENT: no such file or directory, open '/builds/proj/builds/proj/app/style/_fonts.scss'
```

Fixed the build, changed the tests to normalize backslash path separator to forward-slash(windows accept both separators, btw).