### PR TITLE
Cleanup of readme & other files for Dart Sass. Closes #205

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
+# Unreleased
+* Remove support for many options that haven't worked since the version 3.0.0 switch to Dart Sass. For sourcemap-related options, see Brunch's [`sourceMaps`](https://brunch.io/docs/config#sourcemaps).
+
 # sass-brunch 3.0.0 (Mar 19, 2020)
 * Update for brunch 3
-* Switch to native node sass, remove support for ruby-sass
+* Switch to the pure-JavaScript release of Dart Sass, remove support for libsass and ruby-sass
 
 # sass-brunch 2.6.2 (Apr 5, 2016)
 * Add source map support for `native`

--- a/README.md
+++ b/README.md
@@ -12,12 +12,6 @@ Set additional include paths:
 includePaths: ['node_modules/foundation/scss']
 ```
 
-Print line number references as comments or sass's FireSass fake media query:
-
-```javascript
-debug: 'comments' // or set to 'debug' for the FireSass-style output
-```
-
 Set the precision for arithmetic operations. This is useful for building Bootstrap, Zurb Foundation, and the like.
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -12,12 +12,6 @@ Set additional include paths:
 includePaths: ['node_modules/foundation/scss']
 ```
 
-To enable embedded source maps, pass the option `sourceMapEmbed`. This is only supported in _native_ mode; Ruby Sass isn't supported.
-
-```javascript
-sourceMapEmbed: true
-```
-
 Use libsass [experimental custom functions](https://github.com/sass/node-sass#functions--v300---experimental):
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -12,18 +12,17 @@ Set additional include paths:
 includePaths: ['node_modules/foundation/scss']
 ```
 
-Use libsass [experimental custom functions](https://github.com/sass/node-sass#functions--v300---experimental):
+Use [custom functions](https://sass-lang.com/documentation/js-api/interfaces/LegacySharedOptions#functions) (only synchronous functions are supported):
 
 ```javascript
-var types = require('node-sass').types
+var types = require('sass').types
 module.exports = {
   plugins: {
     sass: {
-      mode: 'native', // custom functions are only supported in 'native' mode
       functions: {
-        sin: function(val) { types.Number(Math.sin(val.getValue())) },
-        cos: function(val) { types.Number(Math.cos(val.getValue())) },
-        tan: function(val) { types.Number(Math.tan(val.getValue())) }
+        'example($foo, $bar)': function(foo, bar) {
+          return new types.String("I'm an example")
+        }
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -12,38 +12,11 @@ Set additional include paths:
 includePaths: ['node_modules/foundation/scss']
 ```
 
-Set the precision for arithmetic operations. This is useful for building Bootstrap, Zurb Foundation, and the like.
-
-```javascript
-precision: 8
-```
-
-Allow the ruby compiler to write its normal cache files in `.sass-cache` (disabled by default).
-This can vastly improve compilation time.
-
-```javascript
-allowCache: true
-```
-
 To enable embedded source maps, pass the option `sourceMapEmbed`. This is only supported in _native_ mode; Ruby Sass isn't supported.
 
 ```javascript
 sourceMapEmbed: true
 ```
-
-To include the source files' name/path in either debug mode, create a parent file that `@include` your actual sass/scss source. Make sure the source files are renamed to start with an underscore (`_file.scss`), or otherwise exclude them from the build so they don't get double-included.
-
-To pass any other options to sass:
-
-```javascript
-options: ['--quiet']
-```
-
-Use sass/compass installed in custom location:
-```javascript
-gem_home: './gems'
-```
-This could be useful for the environment which doesn't allow to install gems globally, such as CI server.
 
 Use libsass [experimental custom functions](https://github.com/sass/node-sass#functions--v300---experimental):
 

--- a/index.js
+++ b/index.js
@@ -105,7 +105,6 @@ class SassCompiler {
         functions: this.config.functions,
         sourceMap: true,
         omitSourceMapUrl: true,
-        sourceMapEmbed: !this.optimize && this.config.sourceMapEmbed,
         sourceMapRoot: source.path,
         importer: nodeSassGlobImporter(),
       });

--- a/index.js
+++ b/index.js
@@ -92,9 +92,6 @@ class SassCompiler {
     const {data, path} = source;
     if (!data.trim().length) return Promise.resolve({data: ''}); // skip empty source files
 
-    const debugMode = this.config.debug;
-    const hasComments = debugMode === 'comments' && !this.optimize;
-
     try {
       // Sync render is >2x faster (without using external deps.) according to
       // dart-sass docs: https://github.com/sass/dart-sass#javascript-api
@@ -103,7 +100,6 @@ class SassCompiler {
         data: source.data,
         includePaths: this._getIncludePaths(source.path),
         outputStyle: this.optimize ? 'compressed' : 'expanded',
-        sourceComments: hasComments,
         indentedSyntax: sassRe.test(source.path),
         outFile: 'a.css',
         functions: this.config.functions,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "brunch-compiler",
     "sass",
     "scss",
-    "libsass",
     "dart-sass"
   ],
   "repository": {


### PR DESCRIPTION
As promised in #205, I deleted all info irrelevant to Dart Sass from the readme. While researching to find out what info was still relevant, I discovered this package still supported some options that had no effect with Dart Sass, so I removed them from the code as well:

- `debug` mapped to the `sourceComments` option, which [Dart Sass does not intend to support](https://www.npmjs.com/package/sass#api).
- `sourceMapEmbed` [has no effect with the `omitSourceMapUrl` this package uses](https://github.com/sass/dart-sass/blob/55cb4fd5097975dc8fe11fa423ac9c1520c4f950/lib/src/node/legacy.dart#L399) (and is better handled by Brunch's `sourceMaps: inline` anyways).

Other changes of note:
- Removed libsass keyword
- Noted my changes in the changelog under an "Unreleased" header
- Edited the changelog to clarify 3.0.0's Sass implementation support